### PR TITLE
Update package to the newest stubby version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "stubby": "~0.3.0"
+    "stubby": "~0.3.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "stubby": "~0.2.0"
+    "stubby": "~0.3.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt": "~0.4.1",
-    "supertest": "~0.7.1",
+    "supertest": "~1.2.0",
     "grunt-release": "~0.5.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
This will fix the `path error` in node 6.

Sidenote there are some breaking changes:
https://github.com/mrak/stubby4node/releases/tag/0.3.0
